### PR TITLE
Check if `switch_to_network` and `restore_current_network` functions exist before calling them

### DIFF
--- a/bu-alerts.php
+++ b/bu-alerts.php
@@ -111,9 +111,13 @@ class BU_AlertsPlugin {
 
 		// Set network level site option for an alert, given the type and message.
 		foreach ( $site_ids as $site_id ) {
-			switch_to_network( $site_id );
+			if( function_exists( 'switch_to_network' ) ) {
+				switch_to_network( $site_id );
+			}
 			update_site_option( $site_option, $alert );
-			restore_current_network();
+			if( function_exists( 'restore_current_network' ) ) {
+				restore_current_network();
+			}
 		}
 
 		// Flushing the cache should affect every site in every network?
@@ -140,9 +144,13 @@ class BU_AlertsPlugin {
 		$site_option = self::getSiteOptionByType( $type );
 
 		foreach ( $site_ids as $site_id ) {
-			switch_to_network( $site_id );
+			if( function_exists( 'switch_to_network' ) ) {
+				switch_to_network( $site_id );
+			}
 			delete_site_option( $site_option );
-			restore_current_network();
+			if( function_exists( 'restore_current_network' ) ) {
+				restore_current_network();
+			}
 		}
 
 		// Flushing the cache should affect every site in every network?

--- a/src/bu-alert-main.php
+++ b/src/bu-alert-main.php
@@ -71,7 +71,11 @@ function get_id_for_domain( $domain ) {
  * @return void
  */
 function remove_alert_option( $alert_option ) {
-	switch_to_network( $alert_option['site_id'] );
+	if( function_exists( 'switch_to_network' ) ) {
+		switch_to_network( $alert_option['site_id'] );
+	}
 	delete_site_option( $alert_option['meta_key'] );
-	restore_current_network();
+	if( function_exists( 'restore_current_network' ) ) {
+		restore_current_network();
+	}
 }


### PR DESCRIPTION
Submitting this pull request to add checks to ensure the `switch_to_network` and `restore_current_network` functions exist before calling them.

This allows the plugin function properly in multisite environments where these functions are not defined.